### PR TITLE
Add CITATION.cff and README with citation information

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use these materials, please cite them as below."
+type: software
+title: "Git for Scientists"
+abstract: "Git for Scientists is an Open Educational Resource: an instructor handbook for a hands-on, four-hour workshop that teaches researchers the foundations of Git and GitHub for collaboration in scientific work. It documents the pedagogy, setup, and run of show so that an educator who was not in the room can teach the workshop from checklists rather than reverse-engineering someone else's setup."
+authors:
+  - family-names: "Schöbitz"
+    given-names: "Lars"
+    orcid: "https://orcid.org/0000-0003-2196-5015"
+    affiliation: "Global Health Engineering, ETH Zurich"
+version: "1.0.0"
+date-released: "2026-07-30"
+doi: "10.5281/zenodo.21703566"
+url: "https://gitforsci.github.io/website/"
+repository-code: "https://github.com/gitforsci/website/"
+license: "CC-BY-4.0"
+keywords:
+  - open-educational-resources
+  - git
+  - github
+  - science
+  - data-stewardship
+  - research-data-management
+  - workshop

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Git for Scientists: CIS Iteration Website
+
+Course website for the May 2025 iteration of Git for Scientists at the ETH Zurich CIS retreat, rendered at <https://gitforsci-cis.github.io/website/>.
+
+## Citation and provenance
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21703566.svg)](https://doi.org/10.5281/zenodo.21703566)
+
+This repository is the May 2025 CIS iteration of [Git for Scientists](https://github.com/gitforsci), an Open Educational Resource. Canonical website: <https://gitforsci.github.io/website/>. This iteration has no snapshot DOI of its own; please cite the canonical course. Citation metadata is in [CITATION.cff](CITATION.cff). Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Adds the canonical CITATION.cff synced from gitforsci/website and a README with the canonical DOI (10.5281/zenodo.21703566), a backlink to the canonical organisation, and the course website. This iteration has no snapshot DOI of its own; it cites the canonical course. Part of the citation propagation across the Git for Scientists org family.